### PR TITLE
Development → main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install CpmfUipsPack dependency
         shell: pwsh
         run: |
-          Install-Module CpmfUipsPack -Scope CurrentUser -Force -MinimumVersion 0.1.0
+          Install-Module CpmfUipsPack -Scope CurrentUser -Force -MinimumVersion 0.2.0
 
       - name: Validate manifest
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Trust PSGallery
+        shell: pwsh
+        run: Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Trust PSGallery
+        shell: pwsh
+        run: Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,34 @@
+name: Sync KB to Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/kb/**'
+
+jobs:
+  wiki-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Clone wiki
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki
+
+      - name: Copy KB articles
+        run: cp docs/kb/*.md wiki/
+
+      - name: Commit and push
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --staged --quiet && echo "No changes" && exit 0
+          git commit -m "Sync KB docs from main @ ${{ github.sha }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.1.1] — 2026-03-21
+
+### Added
+
+- **Pack progress feedback** — `Invoke-CpmfUipsCLI pack` now emits `[pack] Packing <name> …`
+  before dispatching and `[pack] Staged: <file>` for each staged nupkg on success. These
+  `Write-Host` messages are always visible without `-Verbose`, preventing the silent-hang
+  appearance during long uipcli runs.
+
+### Changed
+
+- `RequiredModules` bumped to `CpmfUipsPack 0.1.1` to pick up the noise-filtered failure
+  output and GUID temp-folder fix.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.0] — 2026-03-24
+
+### Added
+
+- **`analyze` subcommand** — dispatches to `Invoke-CpmfUipsAnalyze` in
+  CpmfUipsPack. Returns analyzer output as `[string[]]`.
+- **`-Backend uipcli|uipathcli`** — forwarded to both `pack` and `analyze`
+  subcommands. Defaults to `uipcli` (no breaking change).
+- **`install-uipathcli` / `uninstall-uipathcli` subcommands** — manage the
+  uipathcli Go binary via `Install-UipathcliTool` / `Uninstall-UipathcliTool`.
+
+### Changed
+
+- Requires CpmfUipsPack `0.2.0`.
+
+---
+
 ## [0.1.1] — 2026-03-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to CpmfUipsCLI
+
+## Prerequisites
+
+- PowerShell 7+
+- Git
+- Pester 5: `Install-Module Pester -Scope CurrentUser -Force`
+- PSScriptAnalyzer: `Install-Module PSScriptAnalyzer -Scope CurrentUser -Force`
+- `CpmfUipsPack` installed: `Install-Module CpmfUipsPack -Scope CurrentUser -Force`
+
+## Setup after cloning
+
+```powershell
+# Activate the pre-push hook (once per clone)
+pwsh -File scripts/Install-GitHooks.ps1
+```
+
+This sets `core.hooksPath = ./hooks` in your local git config so that
+`hooks/pre-push` runs automatically before every `git push`.
+
+## Running checks locally
+
+```powershell
+# All Pester tests
+Invoke-Pester ./CpmfUipsCLI/tests/ -Output Normal
+
+# PSScriptAnalyzer
+Invoke-ScriptAnalyzer -Path ./CpmfUipsCLI -Recurse -Settings ./CpmfUipsCLI/PSScriptAnalyzerSettings.psd1
+
+# Validate manifest
+Test-ModuleManifest ./CpmfUipsCLI/CpmfUipsCLI.psd1
+
+# Full pre-push gate (same as the hook)
+pwsh -File scripts/Invoke-PrePushChecks.ps1
+```
+
+## Testing against latest CpmfUipsPack
+
+The tests import `CpmfUipsCLI` by manifest path and mock all `CpmfUipsPack`
+calls, so no live uipcli is needed for the test suite.
+
+To smoke-test against the real pack module:
+
+```powershell
+Import-Module D:\path\to\cpmf-uips-pwshpack\CpmfUipsPack\CpmfUipsPack.psd1 -Force
+Import-Module .\CpmfUipsCLI\CpmfUipsCLI.psd1 -Force
+Invoke-CpmfUipsCLI pack -ProjectJson 'C:\path\to\project.json'
+```
+
+## Branch workflow
+
+- `development` — active development; PRs target this branch
+- `main` — protected; only merged via PR after CI passes
+- Branch protection requires: CI green, no direct pushes
+
+## Pre-push hook
+
+`hooks/pre-push` is a bash shim (tracked in the repo) that calls
+`scripts/Invoke-PrePushChecks.ps1`. It runs PSScriptAnalyzer and Pester and
+blocks the push if either fails.
+
+The hook only activates after running `scripts/Install-GitHooks.ps1` once.
+Without that step git uses `.git/hooks/` (empty on a fresh clone).
+
+## Releasing
+
+1. Bump `ModuleVersion` in `CpmfUipsCLI/CpmfUipsCLI.psd1`
+2. Bump `RequiredModules` `ModuleVersion` if a new `CpmfUipsPack` is required
+3. Add a `## [x.y.z]` entry in `CHANGELOG.md`
+4. Commit, push `development`, open PR → `main`
+5. After merge: `git tag vx.y.z origin/main && git push origin vx.y.z`
+6. The `publish.yml` workflow publishes to PSGallery automatically on a
+   non-prerelease semver tag (`v[0-9]+.[0-9]+.[0-9]+`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,24 @@ blocks the push if either fails.
 The hook only activates after running `scripts/Install-GitHooks.ps1` once.
 Without that step git uses `.git/hooks/` (empty on a fresh clone).
 
+## Dependency range convention
+
+`RequiredModules` uses `ModuleVersion` + `MaximumVersion` to express a patch range:
+
+```powershell
+@{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.0'; MaximumVersion = '0.1.9999' }
+```
+
+This accepts any `0.1.x` patch automatically via `Update-Module`, while blocking
+a future `0.2.0` that may contain breaking changes.
+
+When `CpmfUipsPack` ships a new **minor** version, bump `CpmfUipsCLI`'s own minor
+version and shift both bounds:
+
+```powershell
+@{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.2.0'; MaximumVersion = '0.2.9999' }
+```
+
 ## Releasing
 
 1. Bump `ModuleVersion` in `CpmfUipsCLI/CpmfUipsCLI.psd1`

--- a/CpmfUipsCLI/CpmfUipsCLI.psd1
+++ b/CpmfUipsCLI/CpmfUipsCLI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'CpmfUipsCLI.psm1'
-    ModuleVersion     = '0.1.0'
+    ModuleVersion     = '0.1.1'
     GUID              = '4c877d80-6d0c-403e-b0f2-02120b868ef8'
     Author            = 'Christian Prior-Mamulyan'
     CompanyName       = 'cprima'
@@ -9,7 +9,7 @@
     PowerShellVersion = '7.0'
 
     RequiredModules   = @(
-        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.0' }
+        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.1' }
     )
 
     FunctionsToExport = @(
@@ -24,7 +24,7 @@
             Tags        = @('UiPath', 'RPA', 'NuGet', 'CI', 'pack', 'cli', 'cpmf-uips')
             LicenseUri  = 'https://github.com/rpapub/cpmf-uips-pwshcli/blob/main/LICENSE'
             ProjectUri  = 'https://github.com/rpapub/cpmf-uips-pwshcli'
-            ReleaseNotes = 'Exploratory release. Single Invoke-CpmfUipsCLI dispatcher wrapping all CpmfUipsPack public functions.'
+            ReleaseNotes = 'Patch: pack subcommand now emits "[pack] Packing ..." and "[pack] Staged: ..." Write-Host messages for always-visible terminal feedback. Requires CpmfUipsPack 0.1.1. Full changelog: https://github.com/rpapub/cpmf-uips-pwshcli/blob/main/CHANGELOG.md'
         }
     }
 }

--- a/CpmfUipsCLI/CpmfUipsCLI.psd1
+++ b/CpmfUipsCLI/CpmfUipsCLI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'CpmfUipsCLI.psm1'
-    ModuleVersion     = '0.1.1'
+    ModuleVersion     = '0.2.0'
     GUID              = '4c877d80-6d0c-403e-b0f2-02120b868ef8'
     Author            = 'Christian Prior-Mamulyan'
     CompanyName       = 'cprima'
@@ -9,7 +9,7 @@
     PowerShellVersion = '7.0'
 
     RequiredModules   = @(
-        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.0'; MaximumVersion = '0.1.9999' }
+        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.2.0'; MaximumVersion = '0.2.9999' }
     )
 
     FunctionsToExport = @(
@@ -24,7 +24,7 @@
             Tags        = @('UiPath', 'RPA', 'NuGet', 'CI', 'pack', 'cli', 'cpmf-uips')
             LicenseUri  = 'https://github.com/rpapub/cpmf-uips-pwshcli/blob/main/LICENSE'
             ProjectUri  = 'https://github.com/rpapub/cpmf-uips-pwshcli'
-            ReleaseNotes = 'Patch: pack subcommand now emits "[pack] Packing ..." and "[pack] Staged: ..." Write-Host messages for always-visible terminal feedback. Requires CpmfUipsPack 0.1.1. Full changelog: https://github.com/rpapub/cpmf-uips-pwshcli/blob/main/CHANGELOG.md'
+            ReleaseNotes = 'Add analyze subcommand, -Backend uipcli|uipathcli parameter, install-uipathcli/uninstall-uipathcli subcommands. Requires CpmfUipsPack 0.2.0. Full changelog: https://github.com/rpapub/cpmf-uips-pwshcli/blob/main/CHANGELOG.md'
         }
     }
 }

--- a/CpmfUipsCLI/CpmfUipsCLI.psd1
+++ b/CpmfUipsCLI/CpmfUipsCLI.psd1
@@ -9,7 +9,7 @@
     PowerShellVersion = '7.0'
 
     RequiredModules   = @(
-        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.1' }
+        @{ ModuleName = 'CpmfUipsPack'; ModuleVersion = '0.1.0'; MaximumVersion = '0.1.9999' }
     )
 
     FunctionsToExport = @(

--- a/CpmfUipsCLI/PSScriptAnalyzerSettings.psd1
+++ b/CpmfUipsCLI/PSScriptAnalyzerSettings.psd1
@@ -1,8 +1,7 @@
 @{
     Severity     = @('Error', 'Warning')
     ExcludeRules = @(
-        # Write-Host is intentionally absent from this module (all streams use Write-Verbose/Write-Output).
-        # PSAvoidUsingWriteHost is not excluded — any Write-Host addition should be caught.
         'PSUseBOMForUnicodeEncodedFile'  # files are UTF-8 without BOM throughout
+        'PSAvoidUsingWriteHost'          # CLI wrapper intentionally uses Write-Host for always-visible user feedback
     )
 }

--- a/CpmfUipsCLI/Public/Invoke-CpmfUipsCLI.ps1
+++ b/CpmfUipsCLI/Public/Invoke-CpmfUipsCLI.ps1
@@ -136,7 +136,13 @@ function Invoke-CpmfUipsCLI {
             $remove = @('Force')
             foreach ($k in $remove) { $forwardParams.Remove($k) | Out-Null }
             Write-Verbose "[CpmfUipsCLI] → Invoke-CpmfUipsPack"
-            Write-Output (Invoke-CpmfUipsPack @forwardParams)
+            $projectName = if ($ProjectJson) { Split-Path (Split-Path $ProjectJson -Parent) -Leaf } else { '(unknown)' }
+            Write-Host "[pack] Packing $projectName …"
+            $packResults = @(Invoke-CpmfUipsPack @forwardParams)
+            foreach ($path in $packResults) {
+                Write-Host "[pack] Staged: $(Split-Path $path -Leaf)"
+            }
+            Write-Output $packResults
         }
 
         'install-tool' {

--- a/CpmfUipsCLI/Public/Invoke-CpmfUipsCLI.ps1
+++ b/CpmfUipsCLI/Public/Invoke-CpmfUipsCLI.ps1
@@ -9,13 +9,16 @@ function Invoke-CpmfUipsCLI {
         applied as defaults before forwarding, following the same four-layer hierarchy as CpmfUipsPack.
 
         Subcommands:
-          pack              Invoke-CpmfUipsPack
-          install-tool      Install-CpmfUipsPackCommandLineTool
-          uninstall-tool    Uninstall-CpmfUipsPackCommandLineTool
-          install-config    Install-CpmfUipsPackConfig
-          uninstall-config  Uninstall-CpmfUipsPackConfig
-          install-hook      Install-CpmfUipsPackGitHook
-          diagnose          Get-CpmfUipsPackDiagnostics
+          pack                  Invoke-CpmfUipsPack
+          analyze               Invoke-CpmfUipsAnalyze
+          install-tool          Install-CpmfUipsPackCommandLineTool
+          uninstall-tool        Uninstall-CpmfUipsPackCommandLineTool
+          install-uipathcli     Install-UipathcliTool
+          uninstall-uipathcli   Uninstall-UipathcliTool
+          install-config        Install-CpmfUipsPackConfig
+          uninstall-config      Uninstall-CpmfUipsPackConfig
+          install-hook          Install-CpmfUipsPackGitHook
+          diagnose              Get-CpmfUipsPackDiagnostics
 
     .PARAMETER Command
         The subcommand to execute. Tab-completable.
@@ -80,13 +83,15 @@ function Invoke-CpmfUipsCLI {
     [OutputType([string[]], ParameterSetName = '__AllParameterSets')]
     param(
         [Parameter(Mandatory, Position = 0)]
-        [ValidateSet('pack', 'install-tool', 'uninstall-tool', 'install-config', 'uninstall-config', 'install-hook', 'diagnose')]
+        [ValidateSet('pack', 'analyze', 'install-tool', 'uninstall-tool', 'install-uipathcli', 'uninstall-uipathcli', 'install-config', 'uninstall-config', 'install-hook', 'diagnose')]
         [string] $Command,
 
-        # --- shared / pack ---
+        # --- shared / pack / analyze ---
         [string]   $ProjectJson,
         [string]   $FeedPath,
         [string[]] $Targets,
+        [ValidateSet('uipcli', 'uipathcli')]
+        [string]   $Backend,
         [switch]   $NoBump,
         [switch]   $UseWorktree,
         [switch]   $SkipInstall,
@@ -143,6 +148,31 @@ function Invoke-CpmfUipsCLI {
                 Write-Host "[pack] Staged: $(Split-Path $path -Leaf)"
             }
             Write-Output $packResults
+        }
+
+        'analyze' {
+            $remove = @('FeedPath', 'UseWorktree', 'WorktreeSibling', 'MultiTfm', 'Force')
+            foreach ($k in $remove) { $forwardParams.Remove($k) | Out-Null }
+            Write-Verbose "[CpmfUipsCLI] → Invoke-CpmfUipsAnalyze"
+            $projectName = if ($ProjectJson) { Split-Path (Split-Path $ProjectJson -Parent) -Leaf } else { '(unknown)' }
+            Write-Host "[analyze] Analyzing $projectName …"
+            Write-Output (Invoke-CpmfUipsAnalyze @forwardParams)
+        }
+
+        'install-uipathcli' {
+            $keep = @('ToolBase', 'WhatIf', 'Confirm', 'Verbose')
+            $toRemove = @($forwardParams.Keys) | Where-Object { $_ -notin $keep }
+            foreach ($k in $toRemove) { $forwardParams.Remove($k) | Out-Null }
+            Write-Verbose "[CpmfUipsCLI] → Install-UipathcliTool"
+            Install-UipathcliTool @forwardParams
+        }
+
+        'uninstall-uipathcli' {
+            $keep = @('ToolBase', 'WhatIf', 'Confirm', 'Verbose')
+            $toRemove = @($forwardParams.Keys) | Where-Object { $_ -notin $keep }
+            foreach ($k in $toRemove) { $forwardParams.Remove($k) | Out-Null }
+            Write-Verbose "[CpmfUipsCLI] → Uninstall-UipathcliTool"
+            Uninstall-UipathcliTool @forwardParams
         }
 
         'install-tool' {

--- a/docs/kb/Install-Module-Corporate-Proxy.md
+++ b/docs/kb/Install-Module-Corporate-Proxy.md
@@ -1,0 +1,54 @@
+# Install-Module fails behind a corporate proxy
+
+## Symptom
+
+Running `Install-Module CpmfUipsPack` (or any module from PSGallery) produces:
+
+```
+Exception: End of central directory record could not be found.
+```
+
+## Cause
+
+A corporate proxy with an interstitial / captive-portal page intercepts the
+HTTPS download and returns an HTML page instead of the `.nupkg` file.
+PowerShell saves the HTML as-is and then fails when it tries to open it as a
+ZIP archive.
+
+## Workarounds
+
+### Option A — Pass proxy credentials to `Install-Module`
+
+```powershell
+$cred = Get-Credential   # domain\username + password
+Install-Module CpmfUipsPack -Proxy 'http://proxy.corp.example:8080' -ProxyCredential $cred
+```
+
+### Option B — Download manually, install from local path
+
+1. On a machine that can reach PSGallery (or via a browser after authenticating
+   the proxy interstitial), download the `.nupkg`:
+   `https://www.powershellgallery.com/api/v2/package/CpmfUipsPack`
+
+2. Rename it to `.zip`, extract, then install:
+
+```powershell
+Save-Module CpmfUipsPack -Path C:\Temp\modules -Proxy 'http://proxy.corp.example:8080'
+# — or copy the extracted folder manually —
+Copy-Item C:\Temp\modules\CpmfUipsPack -Destination ($env:PSModulePath -split ';')[0] -Recurse
+```
+
+### Option C — Register an internal NuGet feed
+
+Publish the module to an internal feed (Azure Artifacts, Nexus, ProGet, etc.)
+that is reachable without proxy interception, then point PowerShell at it:
+
+```powershell
+Register-PSRepository -Name Internal -SourceLocation 'https://pkgs.dev.azure.com/…' -InstallationPolicy Trusted
+Install-Module CpmfUipsPack -Repository Internal
+```
+
+## See also
+
+- [PowerShell docs — Install-Module](https://learn.microsoft.com/powershell/module/powershellget/install-module)
+- [about_Profiles — PSModulePath](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_psmodulepath)

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+ROOT="$(git rev-parse --show-toplevel)"
+exec pwsh -NoProfile -File "$ROOT/scripts/Invoke-PrePushChecks.ps1"

--- a/scripts/Install-GitHooks.ps1
+++ b/scripts/Install-GitHooks.ps1
@@ -1,0 +1,20 @@
+<#
+.SYNOPSIS
+    Configures git to use the tracked hooks/ directory for this repository.
+
+.DESCRIPTION
+    Runs `git config core.hooksPath ./hooks` so that the pre-push hook in
+    hooks/pre-push is picked up automatically. Run once after cloning.
+
+.EXAMPLE
+    pwsh -File scripts/Install-GitHooks.ps1
+#>
+[CmdletBinding()]
+param()
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+Set-Location $repoRoot
+
+git config core.hooksPath ./hooks
+Write-Host '[Install-GitHooks] core.hooksPath set to ./hooks'
+Write-Host '[Install-GitHooks] pre-push hook is now active.'

--- a/scripts/Invoke-PrePushChecks.ps1
+++ b/scripts/Invoke-PrePushChecks.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    Runs PSScriptAnalyzer and Pester before a git push. Called by .git/hooks/pre-push.
+
+.DESCRIPTION
+    Exits with code 1 (blocking the push) if any PSScriptAnalyzer findings or
+    Pester test failures are found. Pass -Verbose to see individual Pester test output.
+
+.EXAMPLE
+    # Run manually from repo root
+    pwsh -File scripts/Invoke-PrePushChecks.ps1
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+Set-Location $repoRoot
+
+Write-Host '[pre-push] PSScriptAnalyzer ...'
+$findings = Invoke-ScriptAnalyzer -Path ./CpmfUipsCLI -Recurse -Settings ./CpmfUipsCLI/PSScriptAnalyzerSettings.psd1
+if ($findings) {
+    $findings | ForEach-Object {
+        Write-Host "$($_.Severity)  $($_.RuleName)  $($_.ScriptName):$($_.Line)  $($_.Message)"
+    }
+    Write-Host '[pre-push] FAIL: PSScriptAnalyzer found findings. Push blocked.'
+    exit 1
+}
+Write-Host '[pre-push] PSScriptAnalyzer OK'
+
+Write-Host '[pre-push] Pester ...'
+$result = Invoke-Pester ./CpmfUipsCLI/tests/ -Output Normal -PassThru
+if ($result.FailedCount -gt 0) {
+    Write-Host "[pre-push] FAIL: $($result.FailedCount) test(s) failed. Push blocked."
+    exit 1
+}
+Write-Host "[pre-push] Pester OK ($($result.PassedCount) passed)"


### PR DESCRIPTION
## Summary

- Tracked pre-push hook (`hooks/pre-push` + `scripts/Invoke-PrePushChecks.ps1` + `scripts/Install-GitHooks.ps1`)
- `CONTRIBUTING.md` with development setup, checks, branch workflow, release steps
- `RequiredModules` uses patch-range `ModuleVersion = '0.1.0'; MaximumVersion = '0.1.9999'`
- `PSAvoidUsingWriteHost` excluded in PSScriptAnalyzerSettings (CLI wrapper intentionally uses Write-Host)
- Write-Host progress feedback in pack subcommand

Closes #5, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)